### PR TITLE
Update Yew to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-bootstrap"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Foorack <max@foorack.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/foorack/yew-bootstrap/"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-yew = "0.19"
+yew = { version = "0.20", features = ["csr"] }
 log = "0.4"
 #console_log = { version = "0.2", features = ["color"] }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the dependency next to the regular yew dependency:
 
 ```toml
 [dependencies]
-yew = "0.19"
+yew = "0.20"
 yew-bootstrap = "0.4"
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the dependency next to the regular yew dependency:
 ```toml
 [dependencies]
 yew = "0.20"
-yew-bootstrap = "0.4"
+yew-bootstrap = "0.5"
 ```
 
 Then in the beginning of your application, include the `include_cdn()` or `include_inline()` function to load the required CSS and JS, either from JSDeliver CDN or to inline the CSS:

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,5 +199,5 @@ impl Component for Model {
 }
 
 fn main() {
-    yew::start_app::<Model>();
+    yew::Renderer::<Model>::new().render();
 }


### PR DESCRIPTION
I opted for client-side rendering for `main.rs`, though we may well have been able to use server-side rendering. With the new version we must explicitly choose the renderer. 