### PR TITLE
Implement Navbar Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-bootstrap"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Foorack <max@foorack.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Following Components has been implemented:
 - [ ] Dropdown
 - [ ] List group
 - [ ] Modal
+- [x] Navbar (`<NavBar>, <NavItem>, <NavDropdown>, <NavDropdownItem>`)
 - [ ] Navs & tabs
 - [ ] Offcanvas
 - [ ] Pagination

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the dependency next to the regular yew dependency:
 ```toml
 [dependencies]
 yew = "0.19"
-yew-bootstrap = "0.4"
+yew-bootstrap = "0.4.1"
 ```
 
 Then in the beginning of your application, include the `include_cdn()` or `include_inline()` function to load the required CSS and JS, either from JSDeliver CDN or to inline the CSS:

--- a/src/component/mod.rs
+++ b/src/component/mod.rs
@@ -5,6 +5,7 @@ mod container;
 mod column;
 mod line;
 mod link;
+mod navbar;
 mod row;
 
 pub use self::column::*;
@@ -14,4 +15,5 @@ pub use self::button_group::*;
 pub use self::container::*;
 pub use self::line::*;
 pub use self::link::*;
+pub use self::navbar::*;
 pub use self::row::*;

--- a/src/component/navbar.rs
+++ b/src/component/navbar.rs
@@ -72,3 +72,148 @@ impl Component for NavBarBrand {
         }
     }
 } 
+
+pub struct NavDropdownItem { }
+
+#[derive(Properties, Clone, PartialEq, Eq)]
+pub struct NavDropdownItemProps {
+    #[prop_or_default]
+    pub text: String,
+    #[prop_or_default]
+    pub url: String,
+}
+
+impl Component for NavDropdownItem {
+    type Message = ();
+    type Properties = NavDropdownItemProps;
+
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self {}
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+
+        html! {
+            <li>
+                <a class="dropdown-item" href={props.url.clone()}>{props.text.clone()}</a>
+            </li>
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct NavDropdown { }
+
+#[derive(Properties, Clone, PartialEq)]
+pub struct NavDropdownProps {
+    #[prop_or_default]
+    pub items: Children,
+    /// the id of the link with the dropdown-toggle class, referenced by aria-labelledby
+    #[prop_or_default]
+    pub id: String,
+    #[prop_or_default]
+    pub expanded: bool,
+    #[prop_or_default]
+    pub text: String
+}
+
+impl Component for NavDropdown {
+    type Message = ();
+    type Properties = NavDropdownProps;
+
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self { }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+
+        let expanded = String::from(match props.expanded {
+            true => "true",
+            false => "false"
+        });
+
+        html! {
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id={props.id.clone()} role="button" data-bs-toggle="dropdown" aria-expanded={expanded}>
+                    {props.text.clone()}
+                </a>
+                <ul class="dropdown-menu" aria-labelledby={props.id.clone()}>
+                    { for props.items.iter() }
+                </ul>
+            </li>
+        }
+    }
+}
+
+pub struct NavLinkItem { }
+
+#[derive(Properties, Clone, PartialEq)]
+pub struct NavItemProperties {
+    #[prop_or_default]
+    pub url: Option<String>,
+    #[prop_or_default]
+    pub active: bool,
+    #[prop_or_default]
+    pub disabled: bool,
+    /// ignored if dropdown is Some
+    #[prop_or_default]
+    pub text: String,
+
+    #[prop_or_default]
+    pub dropdown: Children
+}
+
+impl Component for NavLinkItem {
+    type Message = ();
+    type Properties = NavItemProperties;
+
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self {}
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+
+        match &props.dropdown.is_empty() {
+            true => {
+                let mut classes = Classes::new();
+
+                if props.active {
+                    classes.push(String::from("active"));
+                }
+
+                if props.disabled {
+                    classes.push(String::from("disabled"));
+                }
+
+                match props.disabled {
+                    true => {
+                        html! {
+                            <li class="nav-item">
+                                <a class={classes} tabindex="-1" aria-disabled="true" href={props.url.clone()}>
+                                    {props.text.clone()}
+                                </a>
+                            </li>
+                        }
+                    },
+                    false => {
+                        html! {
+                            <li class="nav-item">
+                                <a class={classes} href={props.url.clone()}>
+                                    {props.text.clone()}
+                                </a>
+                            </li>
+                        }
+                    }
+                }
+            },
+            false => {
+                html! {
+                    { for props.dropdown.iter() }
+                }                
+            }
+        }
+    }
+}

--- a/src/component/navbar.rs
+++ b/src/component/navbar.rs
@@ -1,4 +1,5 @@
 use yew::prelude::*;
+use super::Container;
 
 #[derive(Properties, Clone, PartialEq, Eq)]
 pub struct NavBarBrandImage {
@@ -214,6 +215,62 @@ impl Component for NavLinkItem {
                     { for props.dropdown.iter() }
                 }                
             }
+        }
+    }
+}
+
+pub struct NavBar { }
+
+#[derive(Properties, Clone, PartialEq)]
+pub struct NavBarProps {
+    #[prop_or_default]
+    pub items: Children,
+    #[prop_or_default]
+    pub brand: Children,
+    #[prop_or_default]
+    pub class: String,
+
+    /// the id of the div that contains the nav-items
+    #[prop_or_default]
+    pub nav_id: String,
+
+    #[prop_or_default]
+    pub expanded: bool
+}
+
+impl Component for NavBar {
+    type Message = ();
+    type Properties = NavBarProps;
+
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self {}
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+
+        // todo: use our container component?
+        let expanded = String::from(match &props.expanded {
+            true => {
+                "true"
+            },
+            false => {
+                "false"
+            }
+        });
+
+        html! {
+            <nav class={props.class.clone()}>
+                <div class="container-fluid">
+                    { for props.brand.clone() }
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target={format!("#{}", props.nav_id.clone())} aria-controls={props.nav_id.clone()} aria-expanded={expanded} aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id={props.nav_id.clone()}>
+                        { for props.items.clone() }
+                    </div>
+                </div>
+            </nav>
         }
     }
 }

--- a/src/component/navbar.rs
+++ b/src/component/navbar.rs
@@ -1,0 +1,74 @@
+use yew::prelude::*;
+
+#[derive(Properties, Clone, PartialEq, Eq)]
+pub struct NavBarBrandImage {
+    pub url: String,
+    /// descriptive text for users of screen readers
+    pub alt: String,
+    pub width: Option<String>,
+    pub height: Option<String>,
+}
+
+
+pub struct NavBarBrand { }
+
+#[derive(Properties, Clone, PartialEq, Eq)]
+pub struct NavBarBrandProperties {
+    #[prop_or_default]
+    pub text: String,
+    
+    /// Optional brand image
+    #[prop_or_default]
+    pub image: Option<NavBarBrandImage>,
+
+    #[prop_or_default]
+    pub url: Option<String>,
+}
+
+impl Component for NavBarBrand { 
+    type Message = ();
+    type Properties = NavBarBrandProperties;
+
+    fn create(_ctx: &Context<Self>) -> Self {
+        Self {}
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props();
+
+        let url = match &props.url { 
+            Some(u) => u.clone(),
+            None => String::from("#")
+        };
+
+        match &props.image {
+            Some(i) => {
+                match (&i.width, &i.height) {
+                    (None, _) | (_, None)=> {
+                        html! {
+                            <a class="navbar-brand" href={url}>
+                                <img src={i.url.clone()} alt={i.alt.clone()} class="d-inline-block align-text-top" />
+                                {props.text.clone()}
+                            </a>
+                        }
+                    },
+                    (Some(w), Some(h)) => {
+                        html! {
+                            <a class="navbar-brand" href={url}>
+                                <img src={i.url.clone()} alt={i.alt.clone()} width={w.clone()} height={h.clone()} class="d-inline-block align-text-top" />
+                                {props.text.clone()}
+                            </a>
+                        }
+                    }
+                }
+            },
+            None => {
+                html! {
+                    <a class="navbar-brand" href={url}>
+                        {props.text.clone()}
+                    </a>
+                }
+            }
+        }
+    }
+} 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,20 @@ impl Component for Model {
             <p>{ self.value }</p>
         </div>
         */
+
+        let brand = BrandType::BrandSimple { text: String::from("Yew Bootstrap"), url: Some(String::from("https://yew.rs")) };
+
         html! {
             <>
                 {include_inline()}
+                <NavBar nav_id={"test-nav"} class="navbar-expand-lg navbar-light bg-light" brand={brand}>
+                    <NavItem text="link 1" />
+                    <NavItem text="link 2" />
+                    <NavItem text="several items">
+                        <NavDropdownItem text="hello 1" />
+                        <NavDropdownItem text="hello 2" />
+                    </NavItem>
+                </NavBar>
                 <div id="layout" class="p-3">
                     <h1>{ "Containers" }</h1>
                     <Container class="bg-primary">{"Normal"}</Container>
@@ -193,6 +204,7 @@ impl Component for Model {
                     <Line vertical={true} height={Size::Px(50)} /><br />
                     <Line vertical={true} width={Size::Px(100)} /><br />
                 </div>
+                { include_cdn_js() }
             </>
         }
     }

--- a/src/util/dimension.rs
+++ b/src/util/dimension.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, PartialEq, Eq)]
+pub struct Dimension {
+    pub width: String,
+    pub height: String
+}

--- a/src/util/include.rs
+++ b/src/util/include.rs
@@ -28,7 +28,6 @@ pub fn include_cdn_js() -> VNode {
 }
 
 
-
 pub fn include_inline() -> VNode {
     html! {
         <style>

--- a/src/util/include.rs
+++ b/src/util/include.rs
@@ -11,6 +11,24 @@ pub fn include_cdn() -> VNode {
     }
 }
 
+
+pub fn include_cdn_js() -> VNode {
+    html! {
+        <>
+            <link data-trunk={"true"} rel="copy-file" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js.map" />
+            <script
+                src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+                data-trunk={"true"}
+                integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+                crossorigin="anonymous"
+            >
+            </script>
+        </>
+    }
+}
+
+
+
 pub fn include_inline() -> VNode {
     html! {
         <style>

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,9 @@
 mod color;
 mod include;
 mod size;
+mod dimension;
 
 pub use self::color::*;
 pub use self::include::*;
 pub use self::size::*;
+pub use self::dimension::*;


### PR DESCRIPTION
This PR implements the Navbar component and several required dependent components: `<NavBar>, <NavItem>, <NavDropdown>, <NavDropdownItem>`

This component requires JavaScript, so I implemented `include_cdn_js()`. I gave the inline version a shot, but it's remarkably difficult for JavaScript. I'm not yet familiar enough with `trunk` to let inline JavaScript sneak past it. 