### PR TITLE
Add the ability to specify a modal size

### DIFF
--- a/packages/yew-bootstrap/Cargo.toml
+++ b/packages/yew-bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-bootstrap"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["Matthew Scheffel <matt@dataheck.com>", "Foorack <max@foorack.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/yew-bootstrap/README.md
+++ b/packages/yew-bootstrap/README.md
@@ -68,7 +68,7 @@ There is currently no indication of which version of Bootstrap is targeted, howe
 - [ ] Collapse
 - [ ] Dropdown
 - [ ] List group
-- [x] Modal
+- [x] Modal ([component::Modal])
 - [x] Navbar ([component::NavBar], [component::NavItem], [component::NavDropdown], [component::NavDropdownItem])
 - [ ] Navs & tabs
 - [ ] Offcanvas

--- a/packages/yew-bootstrap/src/component/modal.rs
+++ b/packages/yew-bootstrap/src/component/modal.rs
@@ -1,5 +1,19 @@
 use yew::prelude::*;
 
+#[derive(Clone, PartialEq, Eq)]
+pub enum ModalSize {
+    ExtraLarge,
+    Large,
+    Normal,
+    Small,
+}
+
+impl Default for ModalSize {
+    fn default() -> Self {
+        ModalSize::Normal
+    }
+}
+
 /// # Modal dialog
 /// Modal dialog, parent of [ModalHeader], [ModalBody] and [ModalFooter].
 /// 
@@ -133,7 +147,10 @@ pub struct ModalProps {
     pub id: String,
     /// modal body, typically [ModalHeader], [ModalBody] or [ModalFooter]
     #[prop_or_default]
-    pub children: Children
+    pub children: Children,
+    /// Size of the modal
+    #[prop_or_default]
+    pub size: ModalSize,
 }
 
 impl Component for Modal {
@@ -147,9 +164,19 @@ impl Component for Modal {
     fn view(&self, ctx: &Context<Self>) -> Html {
         let props = ctx.props();
 
+        let mut dialog_classes = Classes::new();
+        dialog_classes.push("modal-dialog");
+
+        match props.size {
+            ModalSize::ExtraLarge => dialog_classes.push("modal-xl"),
+            ModalSize::Large => dialog_classes.push("modal-lg"),
+            ModalSize::Small => dialog_classes.push("modal-sm"),
+            _ => (),
+        }
+
         html! {
             <div class="modal" tabindex="-1" id={props.id.clone()}>
-                <div class="modal-dialog">
+                <div class={dialog_classes}>
                     <div class="modal-content">
                         { for props.children.iter() }
                     </div>

--- a/packages/yew-bootstrap/src/component/modal.rs
+++ b/packages/yew-bootstrap/src/component/modal.rs
@@ -27,7 +27,7 @@ impl Default for ModalSize {
 /// use yew_bootstrap::util::Color;
 /// fn test() -> Html {
 ///     html!{
-///         <Modal id="ExampleModal" size={ModalSize::Normal}>
+///         <Modal id="ExampleModal" size={ModalSize::Large}> // size defaults to Normal
 ///             <ModalHeader title="Modal title" id="ExampleModal"/>
 ///             <ModalBody>
 ///                 <p>{"Modal body text goes here."}</p>

--- a/packages/yew-bootstrap/src/component/modal.rs
+++ b/packages/yew-bootstrap/src/component/modal.rs
@@ -1,5 +1,6 @@
 use yew::prelude::*;
 
+/// Represents the optional size of a Modal dialog, described [here](https://getbootstrap.com/docs/5.1/components/modal/#optional-sizes)
 #[derive(Clone, PartialEq, Eq)]
 pub enum ModalSize {
     ExtraLarge,
@@ -22,11 +23,11 @@ impl Default for ModalSize {
 /// ## Example
 /// ```rust
 /// use yew::prelude::*;
-/// use yew_bootstrap::component::{Modal, ModalHeader, ModalBody, ModalFooter, Button};
+/// use yew_bootstrap::component::{Modal, ModalHeader, ModalBody, ModalFooter, Button, ModalSize};
 /// use yew_bootstrap::util::Color;
 /// fn test() -> Html {
 ///     html!{
-///         <Modal id="ExampleModal">
+///         <Modal id="ExampleModal" size={ModalSize::Normal}>
 ///             <ModalHeader title="Modal title" id="ExampleModal"/>
 ///             <ModalBody>
 ///                 <p>{"Modal body text goes here."}</p>


### PR DESCRIPTION
Introduces a new enum `ModalSize` that allows one to optionally add the `.modal-sm`, `.modal-lg` and `.modal-xl` classes.