### PR TITLE
Add the `active` property to NavDropdown

### DIFF
--- a/packages/yew-bootstrap/src/component/navbar.rs
+++ b/packages/yew-bootstrap/src/component/navbar.rs
@@ -55,7 +55,10 @@ pub struct NavDropdownProps {
     pub expanded: bool,
     /// the text of the link with the dropdown-toggle class
     #[prop_or_default]
-    pub text: AttrValue
+    pub text: AttrValue,
+    /// Top level path is the currently active one
+    #[prop_or_default]
+    pub active: bool
 }
 
 impl Component for NavDropdown {
@@ -74,9 +77,18 @@ impl Component for NavDropdown {
             false => "false"
         });
 
+        
+        let mut dropdown_toggle_classes = Classes::new();
+        dropdown_toggle_classes.push(String::from("nav-link"));
+        dropdown_toggle_classes.push(String::from("dropdown-toggle"));
+
+        if props.active {
+            dropdown_toggle_classes.push(String::from("active"));
+        }
+
         html! {
             <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id={props.id.clone()} role="button" data-bs-toggle="dropdown" aria-expanded={expanded}>
+                <a class={dropdown_toggle_classes} href="#" id={props.id.clone()} role="button" data-bs-toggle="dropdown" aria-expanded={expanded}>
                     {props.text.clone()}
                 </a>
                 <ul class="dropdown-menu" aria-labelledby={props.id.clone()}>
@@ -163,7 +175,7 @@ impl Component for NavItem {
             },
             false => {
                 html! {
-                    <NavDropdown text={props.text.clone()} id={props.id.clone()}>
+                    <NavDropdown text={props.text.clone()} id={props.id.clone()} active={props.active}>
                         { for props.children.iter() }
                     </NavDropdown>
                 }                


### PR DESCRIPTION
Currently if you set a `NavItem` to active when it's being used as a dropdown. It behaves in an unexpected way - the text is not bolded.
I updated the `NavDropdown` component to allow the use of the `active` property so the below code snippet works as one would expect.

```html
<NavItem text={"My Work"} active={curr_path.starts_with("/work")}>
    <NavDropdownItem url={"/work"} text="All Work"/>
    <div class="dropdown-divider"></div>
    <NavDropdownItem url={"/work/skaterxl"} text="Skater XL Multiplayer Mod" />
    <NavDropdownItem url={"/work/blades"} text="Blades of Orterra" />
    <NavDropdownItem url={"/work/website"} text="My Website" />
</NavItem>
```
Before/After picture of example code. 
![image](https://github.com/isosphere/yew-bootstrap/assets/7217842/965be188-8bcf-4a0d-a97d-a81091a4a42b)
![image](https://github.com/isosphere/yew-bootstrap/assets/7217842/208e80c3-27fe-4cf1-9eb4-64ee62d35cc5)
