### PR TITLE
Allow Link and Button to point to a URL

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "yew-bootstrap"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/examples/basics/src/main.rs
+++ b/examples/basics/src/main.rs
@@ -250,6 +250,11 @@ impl Component for Model {
                     <Button style={Color::Primary} disabled={true}>{"Primary"}</Button>
                     <Button style={Color::Secondary} disabled={true}>{"Secondary"}</Button>
 
+                    <h2>{"Links which look like buttons"}</h2>
+                    <Button style={Color::Primary} target={"_blank"} url={"https://github.com/isosphere/yew-bootstrap/"}>{"Primary link"}</Button>
+                    <Button style={Color::Secondary} target={"_blank"} url={"https://github.com/isosphere/yew-bootstrap/"}>{"Secondary link"}</Button>
+                    <Button style={Color::Primary} disabled={true} target={"_blank"} url={"https://github.com/isosphere/yew-bootstrap/"}>{"Disabled link"}</Button>
+
                     <h2>{"Block buttons"}</h2>
                     <div class="d-grid gap-2">
                         <Button style={Color::Primary} block={true}>{"Primary"}</Button>
@@ -267,6 +272,12 @@ impl Component for Model {
                         <Button style={Color::Primary}>{"Primary"}</Button>
                         <Button style={Color::Secondary}>{"Secondary"}</Button>
                     </ButtonGroup>
+
+                    <h1>{"Links"}</h1>
+                    <div class="d-grid gap-2">
+                        <Link text={"Primary link"} style={Color::Primary} url={"https://github.com/isosphere/yew-bootstrap/"} />
+                        <Link text={"Secondary link"} style={Color::Secondary} url={"https://github.com/isosphere/yew-bootstrap/"} />
+                    </div>
 
                     <h1>{"List groups"}</h1>
                     <ListGroup>

--- a/packages/yew-bootstrap/src/component/button.rs
+++ b/packages/yew-bootstrap/src/component/button.rs
@@ -15,16 +15,16 @@ impl Default for ButtonSize {
 }
 
 /// # Button component
-/// Button with various properties, including support for opening or closing a modal 
+/// Button with various properties, including support for opening or closing a modal
 /// dialog [crate::component::Modal].
-/// 
+///
 /// Buttons can be grouped in a [crate::component::ButtonGroup].
-/// 
+///
 /// See [ButtonProps] for a listing of properties.
-/// 
+///
 /// ## Example
 /// Example of a simple button:
-/// 
+///
 /// ```rust
 /// use yew::prelude::*;
 /// use yew_bootstrap::component::Button;
@@ -35,10 +35,10 @@ impl Default for ButtonSize {
 ///     }
 /// }
 /// ```
-/// 
-/// A button can be linked to a [crate::component::Modal] dialog or 
+///
+/// A button can be linked to a [crate::component::Modal] dialog or
 /// close this modal.
-/// 
+///
 /// ```rust
 /// use yew::prelude::*;
 /// use yew_bootstrap::component::Button;
@@ -54,6 +54,19 @@ impl Default for ButtonSize {
 ///                 { "Open Modal" }
 ///             </Button>
 ///         </>
+///     }
+/// }
+/// ```
+///
+/// A button may also link to a web page.
+///
+/// ```rust
+/// use yew::prelude::*;
+/// use yew_bootstrap::component::Button;
+/// use yew_bootstrap::util::Color;
+/// fn test() -> Html {
+///     html!{
+///         <Button style={Color::Primary} text={ "Button text" } url={ "https://getbootstrap.com/docs/5.3/components/buttons/#button-tags" } target={"_blank"} />
 ///     }
 /// }
 /// ```
@@ -109,6 +122,23 @@ pub struct ButtonProps {
     /// true if this button dismisses the modal that contains it
     #[prop_or_default]
     pub modal_dismiss: bool,
+
+    /// URL to direct to when the button is clicked. This turns the button into
+    /// an `<a>` element.
+    ///
+    /// This property is ignored if the button is `disabled` to
+    /// [avoid link functionality caveats][0], which may result in
+    /// [slightly different rendering on some browsers / platforms][1].
+    ///
+    /// [0]: https://getbootstrap.com/docs/5.3/components/buttons/#link-functionality-caveat
+    /// [1]: https://getbootstrap.com/docs/5.3/components/buttons/#button-tags
+    #[prop_or_default]
+    pub url: Option<AttrValue>,
+
+    /// Target frame or window ID for the link. Only used if `url` is set and
+    /// the button is not `disabled`.
+    #[prop_or_default]
+    pub target: Option<AttrValue>,
 }
 
 impl Component for Button {
@@ -157,6 +187,21 @@ impl Component for Button {
                     { for props.children.iter() }
                 </button>
             }
+        } else if let Some(url) = props.url.as_ref().filter(|_| !props.disabled) {
+            html! {
+                <a
+                    class={classes}
+                    disabled={props.disabled}
+                    name={props.name.clone()}
+                    onclick={props.onclick.clone()}
+                    data-bs-dismiss={modal_dismiss}
+                    href={url.clone()}
+                    target={props.target.clone()}
+                >
+                    { &props.text }
+                    { for props.children.iter() }
+                </a>
+            }
         } else {
             html! {
                 <button
@@ -171,6 +216,5 @@ impl Component for Button {
                 </button>
             }
         }
-
     }
 }

--- a/packages/yew-bootstrap/src/component/link.rs
+++ b/packages/yew-bootstrap/src/component/link.rs
@@ -1,22 +1,22 @@
-use yew::prelude::*;
 use crate::util::Color;
+use yew::prelude::*;
 
 /// # Link component
 /// Link component rendered as `<a/>` component. This link can contain
 /// any element.
-/// 
+///
 /// See [LinkProps] for a listing of properties.
-/// 
+///
 /// ## Example
 /// Example of link:
-/// 
+///
 /// ```rust
 /// use yew::prelude::*;
 /// use yew_bootstrap::component::Link;
 /// use yew_bootstrap::util::Color;
 /// fn test() -> Html {
 ///     html!{
-///         <Link style={Color::Primary} stretched={ true } text={ "Link text" }/>
+///         <Link style={Color::Primary} stretched={ true } text={ "Link text" } url={ "https://github.com/isosphere/yew-bootstrap/" }/>
 ///     }
 /// }
 /// ```
@@ -40,6 +40,14 @@ pub struct LinkProps {
     /// Color style
     #[prop_or_default]
     pub style: Option<Color>,
+
+    /// URL to direct to when the link is clicked
+    #[prop_or_default]
+    pub url: Option<AttrValue>,
+
+    /// Target frame or window ID for the link
+    #[prop_or_default]
+    pub target: Option<AttrValue>,
 
     /// Optional text for the link
     #[prop_or_default]
@@ -68,6 +76,9 @@ impl Component for Link {
         html! {
             <a
                 class={classes}
+                role={props.url.is_none().then_some("button")}
+                href={props.url.clone()}
+                target={props.target.clone()}
             >
                 { &props.text }
                 { for props.children.iter() }


### PR DESCRIPTION
Add `url` (`href`) and `target` properties to `Button` and `Link`. This avoids a bunch of JavaScript shenanigans to link to ordinary URLs.

When `ButtonProps::url` is set and `ButtonProps::disabled == false`, `Button` uses an `<a>` tag and a [link-styled button][0] rather than `<button>`.

The name `url` was chosen for consistency with `ListGroupItem`.

I considered putting everything in `Link`, but `Button` styling is different, and there didn't seem to be any sense in duplicating it.

[0]: https://getbootstrap.com/docs/5.3/components/buttons/#button-tags