### PR TITLE
Placate trunk by providing a `<body>` tag, remove icons from `cards` example

### DIFF
--- a/examples/basics/index.html
+++ b/examples/basics/index.html
@@ -6,4 +6,6 @@
     <title>Yew App</title>
 </head>
 
+<body></body>
+
 </html>

--- a/examples/cards/index.html
+++ b/examples/cards/index.html
@@ -6,4 +6,6 @@
     <title>Yew App</title>
 </head>
 
+<body></body>
+
 </html>

--- a/examples/cards/src/main.rs
+++ b/examples/cards/src/main.rs
@@ -67,7 +67,6 @@ impl Component for Model {
         html! {
             <>
                 {include_inline()}
-                {include_cdn_icons()}
                 <div id="layout" class="p-3">
 
                 <h1>{"Basic Cards"}</h1>

--- a/examples/forms/index.html
+++ b/examples/forms/index.html
@@ -6,4 +6,6 @@
     <title>Yew App</title>
 </head>
 
+<body></body>
+
 </html>


### PR DESCRIPTION
1 commit is also in #44.

Fixes an issue building the `basics`, `cards` and `forms` examples with recent versions of `trunk`:

```
error from build pipeline

Caused by:
    0: HTML build pipeline failed (1 errors), showing first
    1: failed to finalize asset pipeline
    2: Document has neither a <link data-trunk rel="rust"/> nor a <body>. Either one must be present.
```

The `icons` example already builds fine.

While here, remove Bootstrap Icons from the `cards` example, because it is never used, and `include_cdn_icons()` is deprecated.
