### PR TITLE
Fix typo in accordion name

### DIFF
--- a/packages/yew-bootstrap/src/component/accordion.rs
+++ b/packages/yew-bootstrap/src/component/accordion.rs
@@ -257,7 +257,7 @@ pub struct AccordionProps {
 /// ```
 #[function_component]
 pub fn Accordion(props: &AccordionProps) -> Html {
-    let mut classes = classes!("accordian");
+    let mut classes = classes!("accordion");
     if props.flush {
         classes.push("accordion-flush");
     }


### PR DESCRIPTION
There is a bug in accordion created by a typo in accordion's name. This is creating issue with rendering.