### PR TITLE
Implemented on_hide property for Modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,11 +1251,12 @@ dependencies = [
 
 [[package]]
 name = "yew-bootstrap"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "convert_case",
  "gloo-console 0.3.0",
+ "gloo-events 0.2.0",
  "gloo-utils 0.2.0",
  "js-sys",
  "popper-rs",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1302,11 +1302,12 @@ dependencies = [
 
 [[package]]
 name = "yew-bootstrap"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "convert_case",
  "gloo-console 0.3.0",
+ "gloo-events 0.2.0",
  "gloo-utils 0.2.0",
  "js-sys",
  "popper-rs",

--- a/examples/basics/src/main.rs
+++ b/examples/basics/src/main.rs
@@ -80,7 +80,7 @@ impl Component for Model {
                         <NavDropdownItem text="No icon" onclick={onclick.clone()} url="#" />
                     </NavDropdown>
                 </NavBar>
-                <Modal id="ExampleModal">
+                <Modal id="ExampleModal" on_hide={Callback::from(|_| debug!("Modal hidden"))}>
                     <ModalHeader title="Modal title" id="ExampleModal" />
                     <ModalBody>
                         <p>{"Modal body text goes here."}</p>

--- a/packages/yew-bootstrap/Cargo.toml
+++ b/packages/yew-bootstrap/Cargo.toml
@@ -21,6 +21,7 @@ yew = { version = "0.21", features = ["csr"] }
 gloo-console = "0.3"
 wasm-bindgen = "0.2.*"
 web-sys = { version = "0.3.*", features = ["HtmlElement", "MediaQueryList", "MediaQueryListEvent", "ScrollBehavior", "ScrollIntoViewOptions", "ScrollLogicalPosition"] }
+gloo-events = "0.2.0"
 popper-rs = { version = "0.3.0", features = ["yew"] }
 gloo-utils = "0.2.0"
 

--- a/packages/yew-bootstrap/Cargo.toml
+++ b/packages/yew-bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-bootstrap"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Matthew Scheffel <matt@dataheck.com>", "Foorack <max@foorack.com>"]
 edition = "2021"
 license = "MIT"

--- a/packages/yew-bootstrap/src/component/modal.rs
+++ b/packages/yew-bootstrap/src/component/modal.rs
@@ -4,18 +4,13 @@ use gloo_events::EventListenerOptions;
 use gloo_utils::body;
 
 /// Represents the optional size of a Modal dialog, described [here](https://getbootstrap.com/docs/5.1/components/modal/#optional-sizes)
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Default, Clone, PartialEq, Eq)]
 pub enum ModalSize {
     ExtraLarge,
     Large,
+    #[default]
     Normal,
     Small,
-}
-
-impl Default for ModalSize {
-    fn default() -> Self {
-        ModalSize::Normal
-    }
 }
 
 /// # Modal dialog
@@ -193,8 +188,7 @@ impl Component for Modal {
         Self { on_hide: OnHide::new(
             &body,
             _ctx.props().on_hide.clone(),
-        )
-        }
+        )}
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {


### PR DESCRIPTION
Implements an event listener for the bootstrap modal 'hide' event, which can be used for preventing closure if 'save' functionality fails. This allows you to display an error message or something.

I have modified the 'basics' example to print a debug statement to console when the on_hide event fires.
This feature required me to use the gloo_events crate, since I didn't want to implement it from web_sys (which is apparently difficult).

The property is #[prop_or_default], and is a Callback<Event> wrapped in an option, so this should not be a breaking change for any yew projects using the Modal component.